### PR TITLE
Fixes PCL targets in nuspec.

### DIFF
--- a/src/Zlib.Portable.Signed.nuspec
+++ b/src/Zlib.Portable.Signed.nuspec
@@ -32,9 +32,9 @@
         <tags>zip gzip deflate dotnetzip bzip2 lzma portable compression</tags>
     </metadata>
     <files>
-        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.dll" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.pdb" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.xml" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
+        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.dll" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
+        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.pdb" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
+        <file src="Zlib.Portable\bin\Release-Signed\Zlib.Portable.xml" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
         <file src="Zlib.Portable\**\*.cs" exclude="**\obj\**\*.*" target="src" />
     </files>
 </package>

--- a/src/Zlib.Portable.nuspec
+++ b/src/Zlib.Portable.nuspec
@@ -31,9 +31,8 @@
         <tags>zip gzip deflate dotnetzip bzip2 lzma portable compression</tags>
     </metadata>
     <files>
-        <file src="Zlib.Portable\bin\Release\Zlib.Portable.dll" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-        <file src="Zlib.Portable\bin\Release\Zlib.Portable.pdb" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-        <file src="Zlib.Portable\bin\Release\Zlib.Portable.xml" target="lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-        <file src="Zlib.Portable\**\*.cs" exclude="**\obj\**\*.*" target="src" />
+        <file src="Zlib.Portable\bin\Release\Zlib.Portable.dll" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
+        <file src="Zlib.Portable\bin\Release\Zlib.Portable.dll.mdb" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
+        <file src="Zlib.Portable\bin\Release\Zlib.Portable.xml" target="lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\" />
     </files>
 </package>


### PR DESCRIPTION
The PCL targets specified in the nuspec files are
not in cannonical form. As a result, nuget thinks
that Xamarin.iOS is not supported, for example,
so the nupkg cannot be added. This fixes that.